### PR TITLE
Proposal for 2.0.0

### DIFF
--- a/bin/ut_parse_lib.py
+++ b/bin/ut_parse_lib.py
@@ -13,7 +13,7 @@ except ImportError:
 	from urllib.parse import urlparse
 
 preg_rfc1808 = re.compile("://")
-preg_ipv4 = re.compile("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+preg_ipv4 = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 
 #############
 # FUNCTIONS #
@@ -38,7 +38,7 @@ def _loadIANAList(filename="suffix_list_iana.dat"):
     line = f.readline()
     while line:
         # skip comment or empty line
-        if re.search('^\s*(#|$)', line):
+        if re.search(r'^\s*(#|$)', line):
             line = f.readline()
             continue
 
@@ -72,13 +72,13 @@ def _loadMozillaList():
     line = f.readline()
     while line:
         # skip comment or empty line
-        if re.search('^(\s*$|//)', line):
+        if re.search(r'^(\s*$|//)', line):
             line = f.readline()
             continue
 
         # stop at the first whitespace as stated on https://publicsuffix.org/list/
         line = line.lower()
-        ret = re.search('^\s*([^\s]+)', line)
+        ret = re.search(r'^\s*([^\s]+)', line)
         if ret:
             tld_raw = ret.group(1)
             tld_pun = tld_raw.encode('idna')
@@ -158,6 +158,7 @@ def findTLD(netloc, TLDList):
 
         items.insert(0, parts[i])
         candidate = '.'.join(items)
+        candidate = candidate.encode('utf-8')
 
         if candidate in regulars:
             continue

--- a/default/app.conf
+++ b/default/app.conf
@@ -5,7 +5,7 @@ label = URL Toolbox
 [launcher]
 author = Cedric Le Roux
 description = Parse URLs like a Pro.
-version = 1.7
+version = 2.0
 
 [package]
 id = utbox

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -1,32 +1,40 @@
 [ut_shannon_lookup]
 external_cmd = ut_shannon.py word
 fields_list  = word, ut_shannon
+python.version = python3
 
 [ut_parse_simple_lookup]
 external_cmd = ut_parse_simple.py url
 fields_list  = url, ut_scheme, ut_netloc, ut_path, ut_params, ut_query, ut_fragment
+python.version = python3
 
 [ut_parse_extended_lookup]
 external_cmd = ut_parse_extended.py url list
 fields_list  = url, list, ut_scheme, ut_netloc, ut_path, ut_params, ut_query, ut_fragment, ut_domain, ut_tld, ut_domain_without_tld, ut_subdomain, ut_port, ut_subdomain_parts, ut_subdomain_count
+python.version = python3
 
 [ut_meaning_lookup]
 external_cmd = ut_meaning.py word
 fields_list  = word, ut_meaning_ratio
+python.version = python3
 
 [ut_suites_lookup]
 external_cmd = ut_suites.py word set
 fields_list  = word, set, ut_suites
+python.version = python3
 
 [ut_countset_lookup]
 external_cmd = ut_countset.py word set
 fields_list  = word, set, ut_countset
+python.version = python3
 
 [ut_bayesian_lookup]
 external_cmd = ut_bayesian.py word
 fields_list  = word, ut_bayesian
+python.version = python3
 
 [ut_levenshtein_lookup]
 external_cmd = ut_levenshtein.py word1 word2
 fields_list  = word1, word2, ut_levenshtein
+python.version = python3
 


### PR DESCRIPTION
The following MR adds explicit `python.version = python3` entries to stanzas in `transforms.conf`. 
It also adds changes for Python3 that are already in the lasted release on Splunkbase (1.8), but not yet in this repo.

There is also a commit that bumps the version to 2.0.0.